### PR TITLE
Add write-buffer for software-defined cache

### DIFF
--- a/SDCManager.py
+++ b/SDCManager.py
@@ -184,7 +184,8 @@ def on_message(client, userdata, msg):
 
         if msg.topic == "core/edge/" + SDC_id + "/data":
             with conditionLock:
-                sdc.store_data(message)
+                # sdc.store_data(message)
+                sdc.put_to_write_buffer(message)
                 print("Data size: %s" % len(message))
                 # data_size = int(message)
                 # print("Data size: %s" % data_size)
@@ -405,7 +406,8 @@ def main():
     # message_local_client.loop_start()
 
     # Software-Defined Cache runs
-    # sdc.run()
+    sdc.run()
+    print("SDC runs")
     scenario_counter = 1
 
     while scenario_counter <= 4:


### PR DESCRIPTION
- Add write-buffer function on software-defined cache
- Protect write-buffer by threading lock
- Add a thread to store data on a cache
- Add condition locks for checking is_not_empty_buffer and is_not_full_cache
  * When the write-buffer is not empty, the thread for storing data on cache runs.
  * When the cache is not full, the thread for storing data on cache runs.
- Change a function from store_data to put_to_write_buffer